### PR TITLE
Add missing Stop dialog option

### DIFF
--- a/DanceServer/DanceServer/Object/!Dancer.lsl
+++ b/DanceServer/DanceServer/Object/!Dancer.lsl
@@ -86,7 +86,7 @@ menu( list button_list )//le menu
 	{
 		button = "-" + button;
 	}
-	button = "Cancel" + button;
+	button = "Stop" + button;
 	if ( gAvKey == llGetOwner() )   button = "Reset" + button;
 	if ( gIndex > 0 )
 	{


### PR DESCRIPTION
Script already knows to stop dancers, so replaced Cancel with stop as users can press ignore to cancel the menu,
